### PR TITLE
fix passing null as 3rd argument to str_replace

### DIFF
--- a/src/Prometheus/RenderTextFormat.php
+++ b/src/Prometheus/RenderTextFormat.php
@@ -56,9 +56,9 @@ class RenderTextFormat
      */
     private function escapeLabelValue($v): string
     {
-        $v = str_replace("\\", "\\\\", $v);
-        $v = str_replace("\n", "\\n", $v);
-        $v = str_replace("\"", "\\\"", $v);
+        $v = str_replace("\\", "\\\\", $v ?? '');
+        $v = str_replace("\n", "\\n", $v ?? '');
+        $v = str_replace("\"", "\\\"", $v ?? '');
         return $v;
     }
 }


### PR DESCRIPTION
this is one of the forks we have to make it work with php8. after running to end to end tests kibana shows lot of entries like ```app.CRITICAL: Uncaught PHP Exception TypeError: "str_replace(): Argument #3 ($subject) must be of type array|string, null given" at /www/vendor/endclothing/prometheus_client_php/src/Prometheus/RenderTextFormat.php line 59```

This pr tries to fix that. once merged a new tag will be created here. 